### PR TITLE
fix(generics): MultiGeneric<T1, T2, T3> handling

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -62,6 +62,24 @@ describe("java-method-parser", () => {
 		});
 	});
 
+	describe("generics example", () => {
+		const generics = loadFile("generics");
+
+		it("should handle complex generic arguments", () => {
+			expect(javaMethodParser(generics).methods).toHaveLength(1);
+
+			const [method] = javaMethodParser(generics).methods;
+
+			expect(method.args).toHaveLength(3);
+			expect(method.args[0].name).toBe("options");
+			expect(method.args[0].type).toBe("HashMap<T2, T>");
+			expect(method.args[1].name).toBe("key");
+			expect(method.args[1].type).toBe("String");
+			expect(method.args[2].name).toBe("instance");
+			expect(method.args[2].type).toBe("GenericClass<T, T1, T2>");
+		});
+	});
+
 	describe("advanced example", () => {
 		const advanced = loadFile("advanced");
 

--- a/exampleFiles/generics.java
+++ b/exampleFiles/generics.java
@@ -1,0 +1,14 @@
+package com.wix.detox.espresso;
+
+public class GenericClass<T, T1, T2> {
+	public static void setSynchronization(
+			HashMap<T2, T> options,
+			String key,
+			GenericClass<T, T1, T2> instance
+	) {
+			if (options.containsKey(key)) {
+					instance.setSynchronization(options, this);
+			}
+	}
+}
+

--- a/index.js
+++ b/index.js
@@ -23,8 +23,10 @@ const parseClassName = file => {
 const argumentRegex = /(final)? (\w*) (\w*)/;
 const transformArgument = rawArguments => {
 	const argumentParts = rawArguments
-		.split(" ")
-		.filter(part => part && part !== "\n");
+		.split(/ (?![^<]*>)/)
+		.map(p => p && p.trim())
+		.filter(Boolean);
+
 	if (!argumentParts.length) {
 		return null;
 	}
@@ -106,7 +108,7 @@ const parseMethods = file => {
 				returnType,
 				name,
 				args: rawArguments
-					.split(",")
+					.split(/,(?![^<]*>)/)
 					.map(transformArgument)
 					.filter(Boolean)
 			}


### PR DESCRIPTION
Removes a blocker for https://github.com/wix/Detox/pull/1521.
See the comment:
https://github.com/wix/Detox/pull/1521#issuecomment-537517724

Quoting a part of @leanmazzu's comment as-is:

> But there's a problem with this solution. We are using code generation to create `EspressoDetox.js`and this code generation is done with [`java-method-parser`](https://github.com/DanielMSchmidt/java-method-parser). 
> This library is using the comma `,` as argument separator, so when it finds `HashMap<String,Boolean>` it splits this argument and takes it as two different arguments like `HashMap<String` and `Boolean>`. 
> So then the code generator fails as it can't these to anything in the supported types list (I added `HashMap<String,Boolean>` to the list of supported types in `generation/adapters/android.js`).